### PR TITLE
Update isolinux.cfg with Internal Disk Quick wipe

### DIFF
--- a/isoroot/i586/input/isolinux.cfg
+++ b/isoroot/i586/input/isolinux.cfg
@@ -70,19 +70,20 @@ menu color msg07	37;40      #90ffffff #00000000 std
 # NOTE: If you create a custom label, then ensure that the first eight
 #       characters in the label are unique.
 
-LABEL  dban
+LABEL dban
 MENU DEFAULT
 MENU LABEL DBAN (Interactive)
 KERNEL dban.bzi
 APPEND nuke="dwipe" silent vga=785
 
 MENU SEPARATOR
+
 LABEL -
-MENU LABEL Automatic Wipe:
+MENU LABEL Automatic Wipe - Internal Disks Only (no USB, eSATA, Firewire):
 MENU DISABLE
 
-LABEL  autonuke
-MENU LABEL DBAN (Automatic, Default settings, Internal disks only)
+LABEL autonuke
+MENU LABEL DBAN Default (DoD 5220.22-M, 3 passes)
 TEXT HELP
 	Wipe all internal disks
 	Method: DoD Short (passes 1, 2 and 7 of DoD 5220.22-M)
@@ -92,7 +93,24 @@ ENDTEXT
 KERNEL dban.bzi
 APPEND nuke="dwipe --autonuke" silent nousb usbcore.nousb vga=785
 
-LABEL  dod
+LABEL autozero
+MENU LABEL DBAN (Quick/Zeros, 1 pass with verification)
+TEXT HELP
+	Wipe all internal disks
+	Method: Zero fill (1 pass)
+	Verify: On
+	Fingerprinting: On
+ENDTEXT
+KERNEL dban.bzi
+APPEND nuke="dwipe --autonuke --method quick" silent nousb usbcore.nousb vga=785
+
+MENU SEPARATOR
+
+LABEL -
+MENU LABEL Automatic Wipe - All attached disks (includes USB, eSATA, Firewire):
+MENU DISABLE
+
+LABEL dod7pass
 MENU LABEL DBAN (Automatic, All disks, DoD 5220.22-M, 7 passes)
 TEXT HELP
 	Wipe all disks
@@ -103,8 +121,9 @@ ENDTEXT
 KERNEL dban.bzi
 APPEND nuke="dwipe --autonuke --method dod522022m" silent vga=785
 
-LABEL  dod3pass
-MENU LABEL DBAN (Automatic, All disks, DoD Short)
+LABEL dod3pass
+#LABEL dodshort
+MENU LABEL DBAN (Automatic, All disks, DoD 5220.22-M, 3 passes (DoD Short)
 TEXT HELP
 	Wipe all disks
 	Method: DoD Short (passes 1, 2 and 7 of DoD 5220.22-M)
@@ -113,14 +132,9 @@ TEXT HELP
 ENDTEXT
 KERNEL dban.bzi
 APPEND nuke="dwipe --autonuke --method dod3pass" silent vga=785
+# APPEND nuke="dwipe --autonuke --method dodshort" silent vga=785
 
-# This isn't shown on the menu, it's the same as dod3pass
-LABEL  dodshort
-MENU HIDE
-KERNEL dban.bzi
-APPEND nuke="dwipe --autonuke --method dodshort" silent vga=785
-
-LABEL  gutmann
+LABEL gutmann
 MENU LABEL DBAN (Automatic, All disks, Peter Gutmann's Method, 35 passes)
 TEXT HELP
 	Wipe all disks
@@ -131,7 +145,7 @@ ENDTEXT
 KERNEL dban.bzi
 APPEND nuke="dwipe --autonuke --method gutmann" silent vga=785
 
-LABEL  ops2
+LABEL ops2
 MENU LABEL DBAN (Automatic, All disks, OPS-II, 8 passes)
 TEXT HELP
 	Wipe all disks
@@ -142,7 +156,7 @@ ENDTEXT
 KERNEL dban.bzi
 APPEND nuke="dwipe --autonuke --method ops2" silent vga=785
 
-LABEL  paranoid
+LABEL paranoid
 MENU LABEL DBAN (Automatic, All disks, Random data, 8 passes with verification)
 TEXT HELP
 	Wipe all disks
@@ -153,7 +167,7 @@ ENDTEXT
 KERNEL dban.bzi
 APPEND nuke="dwipe --autonuke --method prng --rounds 8 --verify all" silent vga=785
 
-LABEL  prng
+LABEL prng
 MENU LABEL DBAN (Automatic, All disks, Random data, 8 passes with last pass verification)
 TEXT HELP
 	Wipe all disks
@@ -164,7 +178,8 @@ ENDTEXT
 KERNEL dban.bzi
 APPEND nuke="dwipe --autonuke --method prng --rounds 8" silent vga=785
 
-LABEL  quick
+LABEL quick
+#LABEL zero
 MENU LABEL DBAN (Automatic, All disks, Zeros, 1 pass with verification)
 TEXT HELP
 	Wipe all disks
@@ -174,13 +189,7 @@ TEXT HELP
 ENDTEXT
 KERNEL dban.bzi
 APPEND nuke="dwipe --autonuke --method quick" silent vga=785
-
-# This isn't shown on the menu, it's the same as quick
-LABEL  zero
-MENU HIDE
-KERNEL dban.bzi
-APPEND nuke="dwipe --autonuke --method zero" silent vga=785
-
+#APPEND nuke="dwipe --autonuke --method zero" silent vga=785
 
 # Troubleshooting Labels
 MENU SEPARATOR
@@ -189,21 +198,20 @@ LABEL -
 MENU LABEL Troubleshooting:
 MENU DISABLE
 
-LABEL  nofloppy
+LABEL nofloppy
 MENU LABEL DBAN (Interactive, No floppy)
 KERNEL dban.bzi
 APPEND nuke="dwipe" floppy=0,16,cmos vga=785
 
-LABEL  nosilent
+LABEL nosilent
 MENU LABEL DBAN (Interactive, Verbose messages)
 KERNEL dban.bzi
 APPEND nuke="dwipe" vga=785
 
-LABEL  noverify
+LABEL noverify
 MENU LABEL DBAN (Interactive, No verification)
 KERNEL dban.bzi
 APPEND nuke="dwipe --verify off" vga=785
-
 
 # Debugging Labels
 MENU SEPARATOR
@@ -212,18 +220,17 @@ LABEL -
 MENU LABEL Debugging:
 MENU DISABLE
 
-
-LABEL  debug
+LABEL debug
 MENU LABEL DBAN (Shell, Debug messages)
 KERNEL dban.bzi
 APPEND nuke="exec /bin/ash" debug vga=785
 
-LABEL  shell
+LABEL shell
 MENU LABEL DBAN (Shell, Verbose messages)
 KERNEL dban.bzi
 APPEND init=/bin/sh vga=785
 
-LABEL  verbose
+LABEL verbose
 MENU HIDE
 KERNEL dban.bzi
 APPEND nuke="dwipe --method quick" vga=785


### PR DESCRIPTION
* Split menu into 'Internal Disk Only' and 'All Disks'
* Add Internal Disk Quick wipe
* remove doublespaces from LABELs
* rename LABEL dod to dod3pass
* removed most part of the 2 hidden, unused, and commented-out LABELs